### PR TITLE
Always fully process request (and response) bodies

### DIFF
--- a/testutils_test.go
+++ b/testutils_test.go
@@ -80,8 +80,7 @@ func (t *testBody) Read(p []byte) (n int, err error) {
 	if t.step > 0 {
 		p = p[:t.step]
 	}
-	tmp, err := t.body.Read(p)
-	return tmp, err
+	return t.body.Read(p)
 }
 
 func (t *testBody) Close() error {


### PR DESCRIPTION
It seems that io.Reader.Read sometimes returns less bytes than requested even if there still are additional bytes available.

(That's my *first line* of Go code ever, if I should do anything differently please advise!)